### PR TITLE
Don't ignore errors

### DIFF
--- a/inject.go
+++ b/inject.go
@@ -255,5 +255,6 @@ func main() {
 		UseServiceVip:           *useServiceVip,
 	}
 
-	intoResourceFile(params, reader, writer)
+	err = intoResourceFile(params, reader, writer)
+	dieIf(err)
 }


### PR DESCRIPTION
Problem: I was ignoring errors from intoResourceFile, so inject.go was failing silently 
Solution: Add check for errors

Fixes #3 