### PR TITLE
Supply an imagePullPolicy to the initContainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ initContainers:
     - "L5D" # linkerd Daemonset service name, uppercased
     - -m
     - "false" # set to true if running in minikube
+  imagePullPolicy: IfNotPresent
   securityContext:
     capabilities:
       add:

--- a/inject.go
+++ b/inject.go
@@ -115,6 +115,7 @@ func injectIntoPodTemplateSpec(p *Params, t *v1.PodTemplateSpec) error {
 				},
 			},
 		},
+		"imagePullPolicy": "IfNotPresent",
 		"securityContext": map[string]interface{}{
 			"capabilities": map[string]interface{}{
 				"add": []string{"NET_ADMIN"},

--- a/inject.go
+++ b/inject.go
@@ -49,6 +49,7 @@ import (
 		    - "L5D" # linkerd Daemonset service name, uppercased
 		    - -m
 		    - "false" # set to true if running in minikube
+		  imagePullPolicy: IfNotPresent
 		  securityContext:
 		    capabilities:
 		      add:


### PR DESCRIPTION
People running Kubernetes 1.5 will run into `spec.template.spec.initContainers[0].imagePullPolicy: Required value` as this was before https://github.com/kubernetes/kubernetes/issues/38542 was fixed.